### PR TITLE
Allow user to pass in a python boolean to layers.batch_norm

### DIFF
--- a/aiutils/tftools/batch_normalizer.py
+++ b/aiutils/tftools/batch_normalizer.py
@@ -48,8 +48,6 @@ class BatchNorm():
                     training, lambda: self.get_normalizer(input, True),
                     lambda: self.get_normalizer(input, False))
 
-            print self.output
-
     def get_normalizer(self, input, train_flag):
         if train_flag:
             self.mean, self.variance = tf.nn.moments(input, self.axes)

--- a/aiutils/tftools/layers.py
+++ b/aiutils/tftools/layers.py
@@ -111,12 +111,12 @@ def batch_norm(input,
 
     Args:
         input (tensor): Tensor to be batch normalized
-        training (bool tensor): Boolean tensor of shape []
+        training (bool tensor, bool): Boolean tensor of shape [] or python boolean
         decay (float): Decay used for exponential moving average
         epsilon (float): Small constant added to variance to prevent
             division of the form 0/0
         name (string): variable scope name
-        reuse_vars (bool): Value passed to reuse keyword argument of 
+        reuse_vars (bool): Value passed to reuse keyword argument of
             tf.variable_scope. This only reuses the offset and scale variables, 
             not the moving average shadow variable.
 

--- a/tests/test_tftools.py
+++ b/tests/test_tftools.py
@@ -98,9 +98,6 @@ def test_batch_norm_4d():
         y2 = layers.batch_norm(x, True, name='bn2')
         y3 = layers.batch_norm(x, False, name='bn3')
 
-        print y
-        print y2
-
         sess = tf.Session()
         sess.run(tf.initialize_all_variables())
 
@@ -109,8 +106,6 @@ def test_batch_norm_4d():
         y_hat_2 = sess.run(y2, feed_dict={x: x_})
         y_hat_3 = sess.run(y3, feed_dict={x: x_})
 
-        print y_hat
-        print y_hat_2
         assert y_hat.shape == x_.shape
         assert y_hat_2.shape == x_.shape
         assert y_hat_3.shape == x_.shape


### PR DESCRIPTION
for the training variable.  This should save some computation time during the computation
graph and some memory.  Addresses #30.